### PR TITLE
Added precise type annotation for kwargs

### DIFF
--- a/alana/prompt.py
+++ b/alana/prompt.py
@@ -10,7 +10,7 @@ from alana.color import red, yellow
 from alana import globals
 
 
-class RequestParams(TypedDict):
+class RequestParams(TypedDict, total=False):
     metadata: message_create_params.Metadata | NotGiven
     stop_sequences: List[str] | NotGiven
     stream: Literal[False] | Literal[True] | NotGiven

--- a/alana/prompt.py
+++ b/alana/prompt.py
@@ -1,10 +1,26 @@
-from typing import List, Dict, Optional, Union, Literal, Any
-from alana.color import red, yellow
 import re
 import os
-from anthropic import Anthropic
-from anthropic.types import Message, MessageParam
+import httpx
+from typing import List, Dict, Optional, Union, Literal, Any, TypedDict, Unpack
+from anthropic import Anthropic, NotGiven
+from anthropic._types import Headers, Query, Body
+from anthropic.types import Message, MessageParam, message_create_params
+
+from alana.color import red, yellow
 from alana import globals
+
+
+class RequestParams(TypedDict):
+    metadata: message_create_params.Metadata | NotGiven
+    stop_sequences: List[str] | NotGiven
+    stream: Literal[False] | Literal[True] | NotGiven
+    top_k: int | NotGiven
+    top_p: float | NotGiven
+    extra_headers: Headers | None
+    extra_query: Query | None
+    extra_body: Body | None
+    timeout: float | httpx.Timeout | None | NotGiven
+
 
 def get_xml_pattern(tag: str):
     """Return regex pattern for getting contents of <tag/> XML tags."""
@@ -47,7 +63,7 @@ def respond(content: str, messages: Optional[List[MessageParam]] = None, role: L
     ))
     return messages
 
-def gen(user: Optional[str] = None, system: str = "", messages: Optional[List[MessageParam]] = None, append: bool = True, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens = 1024, temperature=1.0, loud=True, **kwargs: Any) -> str:
+def gen(user: Optional[str] = None, system: str = "", messages: Optional[List[MessageParam]] = None, append: bool = True, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens = 1024, temperature=1.0, loud=True, **kwargs: Unpack[RequestParams]) -> str:
     """Generate a response from Claude. Returns the text content (`str`) of Claude's response. If you want the Message object instead, use `gen_msg`.
     
     Args:
@@ -121,7 +137,7 @@ def gen(user: Optional[str] = None, system: str = "", messages: Optional[List[Me
         )
     return output.content[0].text
 
-def gen_msg(messages: List[MessageParam], system: str = "", model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens = 1024, temperature=1.0, loud=True, **kwargs: Any) -> Message:
+def gen_msg(messages: List[MessageParam], system: str = "", model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens = 1024, temperature=1.0, loud=True, **kwargs: Unpack[RequestParams]) -> Message:
     """Generate a response from Claude using the Anthropic API.
 
     Args:
@@ -182,7 +198,7 @@ def gen_msg(messages: List[MessageParam], system: str = "", model: str = globals
 
     return message
 
-def gen_examples_list(instruction: str, n_examples: int = 5, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens: int = 1024, temperature=1.0, **kwargs: Any) -> List[str]:
+def gen_examples_list(instruction: str, n_examples: int = 5, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens: int = 1024, temperature=1.0, **kwargs: Unpack[RequestParams]) -> List[str]:
     """Uses Claude to generate a Python list of few-shot examples for a given natural language instruction.
 
     Args:
@@ -223,7 +239,7 @@ def gen_examples_list(instruction: str, n_examples: int = 5, model: str = global
     model_output: str = gen(user=user, system=system, model=model, api_key=api_key, max_tokens=max_tokens, temperature=temperature, **kwargs)
     return get_xml(tag='example', content=model_output)
 
-def gen_examples(instruction: str, n_examples: int = 5, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens: int = 1024, temperature=1.0, **kwargs: Any) -> str:
+def gen_examples(instruction: str, n_examples: int = 5, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens: int = 1024, temperature=1.0, **kwargs: Unpack[RequestParams]) -> str:
     """Generate a formatted string containing few-shot examples for a given natural language instruction. Uses `gen_examples_list`.
 
     Args:
@@ -257,7 +273,7 @@ def gen_examples(instruction: str, n_examples: int = 5, model: str = globals.DEF
     formatted_examples: str = "\n<examples>\n<example>" + '</example>\n<example>'.join(examples) + "</example>\n</examples>"
     return formatted_examples
 
-def gen_prompt(instruction: str, messages: Optional[List[MessageParam]] = None, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens: int = 1024, temperature=1.0, **kwargs: Any) -> Dict[Literal["system", "user", "full"], Union[str, List]]:
+def gen_prompt(instruction: str, messages: Optional[List[MessageParam]] = None, model: str = globals.DEFAULT_MODEL, api_key: Optional[str] = None, max_tokens: int = 1024, temperature=1.0, **kwargs: Unpack[RequestParams]) -> Dict[Literal["system", "user", "full"], Union[str, List]]:
     """Meta-prompter! Generate a prompt given an arbitrary instruction.
     
     Args:
@@ -316,7 +332,7 @@ def gen_prompt(instruction: str, messages: Optional[List[MessageParam]] = None, 
         user_prompt = user_prompt[0]
     return {"system": system_prompt, "user": user_prompt, "full": full_output}
 
-def pretty_print(var: Any, loud: bool = True, model: str = "sonnet", **kwargs) -> str:
+def pretty_print(var: Any, loud: bool = True, model: str = "sonnet", **kwargs: Unpack[RequestParams]) -> str:
     """Pretty-print an arbitrary variable. By default, uses Sonnet (not globals.DEFAULT_MODEL).
 
     Args:

--- a/alana/prompt.py
+++ b/alana/prompt.py
@@ -1,17 +1,17 @@
 import re
 import os
-import httpx
-from typing import List, Dict, Optional, Union, Literal, Any, TypedDict, Unpack
+from typing import List, Dict, Optional, Union, Literal, Any, TypedDict, Unpack, Tuple
 from anthropic import Anthropic, NotGiven
 from anthropic._types import Headers, Query, Body
-from anthropic.types import Message, MessageParam, message_create_params
+from anthropic.types import Message, MessageParam
+from anthropic.types.message_create_params import Metadata
 
 from alana.color import red, yellow
 from alana import globals
 
 
 class RequestParams(TypedDict, total=False):
-    metadata: message_create_params.Metadata | NotGiven
+    metadata: Metadata | NotGiven
     stop_sequences: List[str] | NotGiven
     stream: Literal[False] | Literal[True] | NotGiven
     top_k: int | NotGiven
@@ -19,7 +19,7 @@ class RequestParams(TypedDict, total=False):
     extra_headers: Headers | None
     extra_query: Query | None
     extra_body: Body | None
-    timeout: float | httpx.Timeout | None | NotGiven
+    timeout: float | Union[Optional[float], Tuple[Optional[float], Optional[float], Optional[float], Optional[float]]] | None | NotGiven
 
 
 def get_xml_pattern(tag: str):

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,5 @@ print(messages)  # [{'role': 'user', 'content': 'Hello, Claude!'}, {'role': 'ass
    install_requires=[
       'anthropic',
       'colorama',
-      'httpx',
    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -91,5 +91,6 @@ print(messages)  # [{'role': 'user', 'content': 'Hello, Claude!'}, {'role': 'ass
    install_requires=[
       'anthropic',
       'colorama',
+      'httpx',
    ],
 )


### PR DESCRIPTION
Regarding #2 

- Created `RequestParams` class with type annotations used in `create` method of Anthropic `Messages` class and set it with `total` flag `False`
- Added to all `**kwargs` following type hint `Unpack[RequestParams]`
- Added `httpx` package to **setup.py** requirements and updated imports

Closes #2 
