### PR TITLE
Style ci and readme update

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,4 +17,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install black
       - name: Format code
-        run: black .
+        run: black . --check

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,30 @@ The documentation for this project is hosted at [utils.alana.computer](https://u
   - `alana.remove_xml` to strip certain XML tag-enclosed content from a string (along with the tags). This is primarily intended to get rid of "<reasoning>...</reasoning>" strings. ⚠️ Regex parsing of XML may be unreliable!
 - A bunch of aliases (Try: `alana.few_shot`, `alana.n_shot`, or `alana.xml`)
 
-## Testing
+## Contributing
+A big welcome and thank you for considering contributing to alana-utilities open source project! It’s people like you that make it a reality for users in our community.
+
+Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the developers managing and developing these open source projects. In return, we will reciprocate that respect by addressing your issue, assessing changes, and helping you finalize your pull requests.
+
+### Getting started
+For changes that address core functionality or would require breaking changes (e.g. a major release), it's best to open an Issue to discuss your proposal first. This is not required but can save time creating and reviewing changes.
+In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susam/gitpr).
+
+### Style and formating
+We are using [Black](https://github.com/psf/black) for formating and [PyRight](https://github.com/microsoft/pyright) for type checking.
+
+Before pushing your code and making PR make sure that you have run `black .` on your code, otherwise it will fail.
+```commandline
+  $ pip install black
+  $ black.
+```
+To keep types in code consistent:
+```commandline
+  $ pip install pyright
+  $ pyright .
+```
+
+### Testing
 There are simple tests written with `unittest`. I am working on extending the test suite.
 
 You may need to provide your Anthropic API key as an environment variable to run all of the unit tests. See [#10](https://github.com/alat-rights/alana-utilities/issues/10).

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,30 +106,7 @@ The documentation for this project is hosted at [utils.alana.computer](https://u
   - `alana.remove_xml` to strip certain XML tag-enclosed content from a string (along with the tags). This is primarily intended to get rid of "<reasoning>...</reasoning>" strings. ⚠️ Regex parsing of XML may be unreliable!
 - A bunch of aliases (Try: `alana.few_shot`, `alana.n_shot`, or `alana.xml`)
 
-## Contributing
-A big welcome and thank you for considering contributing to alana-utilities open source project! It’s people like you that make it a reality for users in our community.
-
-Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the developers managing and developing these open source projects. In return, we will reciprocate that respect by addressing your issue, assessing changes, and helping you finalize your pull requests.
-
-### Getting started
-For changes that address core functionality or would require breaking changes (e.g. a major release), it's best to open an Issue to discuss your proposal first. This is not required but can save time creating and reviewing changes.
-In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susam/gitpr).
-
-### Style and formating
-We are using [Black](https://github.com/psf/black) for formating and [PyRight](https://github.com/microsoft/pyright) for type checking.
-
-Before pushing your code and making PR make sure that you have run `black .` on your code, otherwise it will fail.
-```commandline
-  $ pip install black
-  $ black.
-```
-To keep types in code consistent:
-```commandline
-  $ pip install pyright
-  $ pyright .
-```
-
-### Testing
+## Testing
 There are simple tests written with `unittest`. I am working on extending the test suite.
 
 You may need to provide your Anthropic API key as an environment variable to run all of the unit tests. See [#10](https://github.com/alat-rights/alana-utilities/issues/10).

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 import os
 
 setup(
-   name='alana',
-   version='0.0.8',  # Update the version number as needed
-   author='Alana',
-   author_email='hi@alana.computer',
-   description='Utilities for Alana, and maybe you too. Mostly geared toward LLM-heavy workflows.',
-   long_description="""
+    name="alana",
+    version="0.0.8",  # Update the version number as needed
+    author="Alana",
+    author_email="hi@alana.computer",
+    description="Utilities for Alana, and maybe you too. Mostly geared toward LLM-heavy workflows.",
+    long_description="""
 🎵 Note: I have been making new releases frequently. Make sure your package is up-to-date!
 
 ⚠️ Warning: This library is in active early development! No guarantees are made for backward compatibility. The library is NOT production-ready.
@@ -73,24 +73,20 @@ alana.gen(user="Hello, Claude!", messages=messages)
 print(messages)  # [{'role': 'user', 'content': 'Hello, Claude!'}, {'role': 'assistant', 'content': "Hello! It's nice to meet you. How are you doing today?"}]
 ```
    """,
-   long_description_content_type="text/markdown",
-   url='https://github.com/alat-rights/alana-utilities',
-   packages=find_packages(),
-   classifiers=[
-         'Development Status :: 3 - Alpha',
-         'Intended Audience :: Developers',
-         'License :: OSI Approved :: MIT License',
-         'Programming Language :: Python :: 3',
-         'Programming Language :: Python :: 3.6',
-         'Programming Language :: Python :: 3.7',
-         'Programming Language :: Python :: 3.8',
-         'Programming Language :: Python :: 3.9',
-   ],
-   keywords='LLM, utilities',  # Add relevant keywords
-   python_requires='>=3.6',
-   install_requires=[
-      'anthropic',
-      'colorama',
-      'numpy'
-   ],
+    long_description_content_type="text/markdown",
+    url="https://github.com/alat-rights/alana-utilities",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+    keywords="LLM, utilities",  # Add relevant keywords
+    python_requires=">=3.6",
+    install_requires=["anthropic", "colorama", "numpy"],
 )

--- a/simple_tests.py
+++ b/simple_tests.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from anthropic.types import Message, MessageParam, ContentBlock, Usage
 from anthropic import RateLimitError, InternalServerError
 from alana import *
-from flaky import flaky
+from flaky import flaky  # type: ignore
 
 
 class TestFunctions(unittest.TestCase):


### PR DESCRIPTION
- Changed `black` command to check code. If it will find any files that need formatting it will fail CI.
- Added contributing to `README.md` with guidelines to run `black` and `pyright`
- Added `type: ignore` on missing import in `simple_tests.py` 